### PR TITLE
revert geth state when arkiv tx fails

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -156,6 +156,8 @@ func ApplyTransactionWithEVM(msg *Message, gp *GasPool, statedb *state.StateDB, 
 
 		if tx.To() != nil && *tx.To() == address.ArkivProcessorAddress {
 
+			snapshot := statedb.Snapshot()
+
 			logs, err := storagetx.ExecuteArkivTransaction(
 				tx.Data(),
 				blockNumber.Uint64(),
@@ -168,6 +170,7 @@ func ApplyTransactionWithEVM(msg *Message, gp *GasPool, statedb *state.StateDB, 
 			status := types.ReceiptStatusSuccessful
 			if err != nil {
 				status = types.ReceiptStatusFailed
+				statedb.RevertToSnapshot(snapshot)
 			}
 
 			fakeReceipt := &types.Receipt{

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -634,13 +634,12 @@ func (st *stateTransition) innerExecute() (*ExecutionResult, error) {
 			st.evm.Context.Transfer(st.evm.StateDB, msg.From, st.to(), value)
 
 			var logs []*types.Log
+			snapshot := st.evm.StateDB.Snapshot()
 			// run the arkiv transaction
 			logs, vmerr = storagetx.ExecuteArkivTransaction(st.msg.Data, st.msg.BlockNumber, st.msg.TransactionHash, st.txIndex, msg.From, st.evm.StateDB)
-			if err != nil {
-				return nil, fmt.Errorf("failed to execute arkiv transaction: %w", err)
-			}
-
-			if vmerr == nil {
+			if vmerr != nil {
+				st.evm.StateDB.RevertToSnapshot(snapshot)
+			} else {
 				// add logs of the arkiv transaction
 				for _, log := range logs {
 					st.evm.StateDB.AddLog(log)


### PR DESCRIPTION
Originally Witold has reported an instance of entity that never got deleted on the marketplace network. Later we have identified a very similar issue on the Mendoza network and did a bit more research:

- Entity `0xecd2a12c2eb50f939446ea4df217d9f907f326196a8f38a0364c0c672b582557` got create at block `436861` and is due to expire at block `439361`
- At block `439361` no log was emitted that the entity got expired. 
- In Ethereum state the entity also existed past the block `439361`
- Later, at the block `439538` the entity got successfuly updated, which should fail, since the entity was due to expire at the block `439361`
- Inspecting list of entities in the Ethereum that are due to expire at the block `439361` on different block heights between `436861` and `439361` showed that the entity somehow 'disappeared' from the expiry set at the block `439359` 
- further inspection of that block showed a transaction that has failed, but we assume that processing of that transaction has still influenced the state, which should not happen.


It turns out that we weren't properly detecting tx failures and reverting to snapshot of the state before the tx if that is the case. This PR fixes the issue.
